### PR TITLE
Add function for getting the body of a request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -40,6 +40,19 @@ impl Request {
         }
     }
 
+    pub fn body(&self) -> &str {
+        let body_start =
+            self.headers.iter()
+                 // find the header with the highest end index
+                .map(|&((_, _), (_, end)): &(Slice, Slice)| end)
+                .max()
+                 // TODO: handle this case!
+                .expect("Request had no headers!");
+        let body_slice = (body_start, self.data.len());
+        str::from_utf8(self.slice(&body_slice))
+            .unwrap()
+    }
+
     fn slice(&self, slice: &Slice) -> &[u8] {
         &self.data[slice.0..slice.1]
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -42,13 +42,16 @@ impl Request {
 
     pub fn body(&self) -> &str {
         let body_start =
-            self.headers.iter()
-                 // find the header with the highest end index
-                .map(|&((_, _), (_, end)): &(Slice, Slice)| end)
-                .max()
-                 // TODO: handle this case!
-                .expect("Request had no headers!");
+            (self.headers.iter().last().expect("Request has no headers!").1).1;
+                //.iter()
+                // // find the header with the highest end index
+                //.map(|&((_, _), (_, end)): &(Slice, Slice)| end)
+                //.max()
+                // // TODO: handle this case!
+                //.expect("Request had no headers!");
+
         let body_slice = (body_start, self.data.len());
+
         str::from_utf8(self.slice(&body_slice))
             .unwrap()
     }


### PR DESCRIPTION
I've added a method to `Request` for getting the message body of an HTTP request. It doesn't currently handle the case where a request has no headers (which makes the logic much more complicated), but besides that, it should work correctly.

I know that in https://github.com/tokio-rs/tokio-minihttp/issues/21#issuecomment-292744527, @alexcrichton recommended that @serayuzgur just use `hyper` if the message body of a request is needed, but I can't use `hyper` in my (admittedly very specific) use-case.