### PR TITLE
don't try parse empty buf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,10 @@ impl Decoder for HttpCodec {
     type Error = io::Error;
 
     fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<Request>> {
+        // don't try parse empty buf
+        if buf.is_empty() {
+            return Ok(None)
+        }
         request::decode(buf)
     }
 }


### PR DESCRIPTION
Decoder recieve empty buf twice after first complete buf.

Why decoder recieve empty buf twice? 
It is issue for tokio-io?

I found it like that
```diff
diff --git a/src/lib.rs b/src/lib.rs
index fc36848..ca56d08 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ impl Decoder for HttpCodec {
     type Error = io::Error;
 
     fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<Request>> {
+        println!("is buf empty - {}", buf.is_empty());
         request::decode(buf)
     }
 }
```

Run `hello-world`
```bash
$ cargo run --example hello-world
is buf empty - false
is buf empty - true
is buf empty - true
```

On simplest GET request
```bash
$ curl -X GET -v http://127.0.0.1:8080/ -v
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/7.57.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: Example
< Content-Length: 13
< Date: Thu, 25 Jan 2018 23:01:55
<
* Connection #0 to host 127.0.0.1 left intact
Hello, world!
```

Any way this PR skip parsing of empty buf as request, that must improve tokio-minihttp performance.

Sorry about my poor English.
